### PR TITLE
feat: auto-focus message input and control send by connection state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@
 
 - Client 자동 재연결 기능 (ClientConfigScreen에서 활성화/간격 설정)
 - Client 수동 재연결 버튼 및 단축키 (`Ctrl+R`)
+- ChatScreen 진입 시 메시지 입력 필드 자동 포커스
+- 포커스가 입력 필드 외부에 있을 때 printable key 입력 시 입력 필드로 리다이렉트
 
 ### Changed
 
+- 메시지 전송을 연결 상태에 따라 제어 (연결 전/끊김 시 비활성화, 연결 성공 시 활성화)
 - ChatScreen 버튼 토글 로직을 `_show_reconnect_ui()` 헬퍼로 통합
 - 자동 재연결 루프를 `_auto_reconnect_loop()`으로 분리하여 `_run_client()` 단순화
 - mode_label 중복 계산을 `_mode_label` 속성으로 통합

--- a/tcp_socket_tool/screens/chat.py
+++ b/tcp_socket_tool/screens/chat.py
@@ -94,12 +94,13 @@ class ChatScreen(Screen):
         yield Static(f"[{self._mode_label}]  연결 대기 중...", id="info-bar")
         yield RichLog(id="log", highlight=True, markup=True)
         with Horizontal(id="input-row"):
-            yield Input(placeholder="메시지 입력 후 Enter", id="msg-input", disabled=True)
+            yield Input(placeholder="메시지 입력 후 Enter", id="msg-input")
             yield Button("전송", id="btn-send", variant="primary", disabled=True)
             yield Button("재연결", id="btn-reconnect", variant="warning")
         yield Footer()
 
     def on_mount(self) -> None:
+        self.query_one("#msg-input", Input).focus()
         if self.mode == "server":
             self._run_server()
         else:
@@ -131,8 +132,8 @@ class ChatScreen(Screen):
         log.info("ChatScreen[%s]: 연결 확립 peer=%s", self.mode, peer)
         info = self.query_one("#info-bar", Static)
         info.update(f"[{self._mode_label}]  연결됨: {peer}")
-        self.query_one("#msg-input", Input).disabled = False
         self.query_one("#btn-send", Button).disabled = False
+        self.query_one("#msg-input", Input).focus()
         self._show_reconnect_ui(False)
         richlog = self.query_one("#log", RichLog)
         richlog.write(f"[green][{ts()}] 연결 성공: {peer}[/green]")
@@ -145,7 +146,6 @@ class ChatScreen(Screen):
             info.update(f"[{self._mode_label}]  {local_ip}:{self.target_port}  |  연결 대기 중...")
         else:
             info.update(f"[{self._mode_label}]  연결 끊김")
-        self.query_one("#msg-input", Input).disabled = True
         self.query_one("#btn-send", Button).disabled = True
         if not self._user_closed:
             self._show_reconnect_ui(True)

--- a/tcp_socket_tool/screens/chat.py
+++ b/tcp_socket_tool/screens/chat.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 import asyncio
 import sys
 
+from textual import events, on, work
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal
-from textual.widgets import Button, Footer, Input, RichLog, Static
 from textual.screen import Screen
-from textual import on, work
+from textual.widgets import Button, Footer, Input, RichLog, Static
 
 from tcp_socket_tool.logging_config import log, ts, get_local_ip
 from tcp_socket_tool.network import TCPConnection
@@ -98,6 +98,15 @@ class ChatScreen(Screen):
             yield Button("전송", id="btn-send", variant="primary", disabled=True)
             yield Button("재연결", id="btn-reconnect", variant="warning")
         yield Footer()
+
+    def on_key(self, event: events.Key) -> None:
+        inp = self.query_one("#msg-input", Input)
+        if self.focused is inp:
+            return
+        if event.is_printable and event.character:
+            inp.focus()
+            inp.insert_text_at_cursor(event.character)
+            event.prevent_default()
 
     def on_mount(self) -> None:
         self.query_one("#msg-input", Input).focus()


### PR DESCRIPTION
## 변경사항

- ChatScreen 진입 시 메시지 입력 필드 자동 포커스
- 포커스가 입력 필드 외부에 있을 때 printable key 입력 시 입력 필드로 리다이렉트
- 메시지 전송을 연결 상태에 따라 제어 (연결 전/끊김 시 비활성화, 연결 성공 시 활성화)

## 이유

사용자가 ChatScreen에서 별도로 입력 필드를 클릭하지 않아도 바로 메시지를 입력할 수 있도록 UX를 개선한다. 연결되지 않은 상태에서는 전송을 비활성화하여 불필요한 에러를 방지한다.

## 테스트 방법

- `python main.py` 실행
  1. Server 모드 → ChatScreen 진입 시 입력 필드에 포커스 확인, 전송 버튼 비활성화 확인
  2. Client 접속 → 전송 버튼 활성화 확인, 메시지 전송 동작 확인
  3. 연결 끊김 → 전송 버튼 비활성화 확인, 입력 필드 포커스 유지 확인
  4. 포커스가 다른 곳에 있을 때 키보드 입력 → 입력 필드로 리다이렉트 확인

Closes #5

---

- [x] 커밋 컨벤션 준수
- [x] 관련 이슈 링크 포함
- [x] 로컬에서 테스트 완료